### PR TITLE
changed all paths /usr/local/tferma to /usr/local/terraferma

### DIFF
--- a/terraferma/dolfin-master/fenics-master/petsc-maint/debug
+++ b/terraferma/dolfin-master/fenics-master/petsc-maint/debug
@@ -6,14 +6,14 @@ proc ModulesHelp { } {
 }
 module-whatis "Sets environment for TerraFERMA and Buckettools dolfin-master with debugging."
 
-setenv       TF_CMAKE_PATH         /usr/local/tferma/dolfin-master/fenics-master/petsc-maint/debug/share/terraferma/cpp
-prepend-path CMAKE_MODULE_PATH     /usr/local/tferma/dolfin-master/fenics-master/petsc-maint/debug/share/buckettools/cmake/modules
-prepend-path PYTHONPATH            /usr/local/tferma/dolfin-master/fenics-master/petsc-maint/debug/lib/python2.7/dist-packages:/usr/local/tferma/dolfin-master/fenics-master/petsc-maint/debug/lib/python2.7/site-packages
-prepend-path DIAMOND_CONFIG_PATH   /usr/local/tferma/dolfin-master/fenics-master/petsc-maint/debug/share/buckettools/diamond
-prepend-path PATH                  /usr/local/tferma/dolfin-master/fenics-master/petsc-maint/debug/bin
+setenv       TF_CMAKE_PATH         /usr/local/terraferma/dolfin-master/fenics-master/petsc-maint/debug/share/terraferma/cpp
+prepend-path CMAKE_MODULE_PATH     /usr/local/terraferma/dolfin-master/fenics-master/petsc-maint/debug/share/buckettools/cmake/modules
+prepend-path PYTHONPATH            /usr/local/terraferma/dolfin-master/fenics-master/petsc-maint/debug/lib/python2.7/dist-packages:/usr/local/terraferma/dolfin-master/fenics-master/petsc-maint/debug/lib/python2.7/site-packages
+prepend-path DIAMOND_CONFIG_PATH   /usr/local/terraferma/dolfin-master/fenics-master/petsc-maint/debug/share/buckettools/diamond
+prepend-path PATH                  /usr/local/terraferma/dolfin-master/fenics-master/petsc-maint/debug/bin
 
 # Special Environment variables for resolving Dynamic Libraries on MacOSX
-prepend-path DYLD_LIBRARY_PATH     /usr/local/tferma/dolfin-master/fenics-master/petsc-maint/debug/lib
+prepend-path DYLD_LIBRARY_PATH     /usr/local/terraferma/dolfin-master/fenics-master/petsc-maint/debug/lib
 
 module load fenics/master/petsc-maint/debug
 

--- a/terraferma/dolfin-master/fenics-master/petsc-maint/reldebug
+++ b/terraferma/dolfin-master/fenics-master/petsc-maint/reldebug
@@ -6,14 +6,14 @@ proc ModulesHelp { } {
 }
 module-whatis "Sets environment for TerraFERMA and Buckettools dolfin-master."
 
-setenv       TF_CMAKE_PATH         /usr/local/tferma/dolfin-master/fenics-master/petsc-maint/reldebug/share/terraferma/cpp
-prepend-path CMAKE_MODULE_PATH     /usr/local/tferma/dolfin-master/fenics-master/petsc-maint/reldebug/share/buckettools/cmake/modules
-prepend-path PYTHONPATH            /usr/local/tferma/dolfin-master/fenics-master/petsc-maint/reldebug/lib/python2.7/dist-packages:/usr/local/tferma/dolfin-master/fenics-master/petsc-maint/reldebug/lib/python2.7/site-packages
-prepend-path DIAMOND_CONFIG_PATH   /usr/local/tferma/dolfin-master/fenics-master/petsc-maint/reldebug/share/buckettools/diamond
-prepend-path PATH                  /usr/local/tferma/dolfin-master/fenics-master/petsc-maint/reldebug/bin
+setenv       TF_CMAKE_PATH         /usr/local/terraferma/dolfin-master/fenics-master/petsc-maint/reldebug/share/terraferma/cpp
+prepend-path CMAKE_MODULE_PATH     /usr/local/terraferma/dolfin-master/fenics-master/petsc-maint/reldebug/share/buckettools/cmake/modules
+prepend-path PYTHONPATH            /usr/local/terraferma/dolfin-master/fenics-master/petsc-maint/reldebug/lib/python2.7/dist-packages:/usr/local/terraferma/dolfin-master/fenics-master/petsc-maint/reldebug/lib/python2.7/site-packages
+prepend-path DIAMOND_CONFIG_PATH   /usr/local/terraferma/dolfin-master/fenics-master/petsc-maint/reldebug/share/buckettools/diamond
+prepend-path PATH                  /usr/local/terraferma/dolfin-master/fenics-master/petsc-maint/reldebug/bin
 
 # Special Environment variables for resolving Dynamic Libraries on MacOSX
-prepend-path DYLD_LIBRARY_PATH     /usr/local/tferma/dolfin-master/fenics-master/petsc-maint/reldebug/lib
+prepend-path DYLD_LIBRARY_PATH     /usr/local/terraferma/dolfin-master/fenics-master/petsc-maint/reldebug/lib
 
 module load fenics/master/petsc-maint/reldebug
 

--- a/terraferma/master/fenics-tferma-master/petsc-maint/debug
+++ b/terraferma/master/fenics-tferma-master/petsc-maint/debug
@@ -6,14 +6,14 @@ proc ModulesHelp { } {
 }
 module-whatis "Sets environment for TerraFERMA and Buckettools with debugging."
 
-setenv       TF_CMAKE_PATH         /usr/local/tferma/master/fenics-tferma-master/petsc-maint/debug/share/terraferma/cpp
-prepend-path CMAKE_MODULE_PATH     /usr/local/tferma/master/fenics-tferma-master/petsc-maint/debug/share/buckettools/cmake/modules
-prepend-path PYTHONPATH            /usr/local/tferma/master/fenics-tferma-master/petsc-maint/debug/lib/python2.7/dist-packages:/usr/local/tferma/master/fenics-tferma-master/petsc-maint/debug/lib/python2.7/site-packages
-prepend-path DIAMOND_CONFIG_PATH   /usr/local/tferma/master/fenics-tferma-master/petsc-maint/debug/share/buckettools/diamond
-prepend-path PATH                  /usr/local/tferma/master/fenics-tferma-master/petsc-maint/debug/bin
+setenv       TF_CMAKE_PATH         /usr/local/terraferma/master/fenics-tferma-master/petsc-maint/debug/share/terraferma/cpp
+prepend-path CMAKE_MODULE_PATH     /usr/local/terraferma/master/fenics-tferma-master/petsc-maint/debug/share/buckettools/cmake/modules
+prepend-path PYTHONPATH            /usr/local/terraferma/master/fenics-tferma-master/petsc-maint/debug/lib/python2.7/dist-packages:/usr/local/terraferma/master/fenics-tferma-master/petsc-maint/debug/lib/python2.7/site-packages
+prepend-path DIAMOND_CONFIG_PATH   /usr/local/terraferma/master/fenics-tferma-master/petsc-maint/debug/share/buckettools/diamond
+prepend-path PATH                  /usr/local/terraferma/master/fenics-tferma-master/petsc-maint/debug/bin
 
 # Special Environment variables for resolving Dynamic Libraries on MacOSX
-prepend-path DYLD_LIBRARY_PATH     /usr/local/tferma/master/fenics-tferma-master/petsc-maint/debug/lib
+prepend-path DYLD_LIBRARY_PATH     /usr/local/terraferma/master/fenics-tferma-master/petsc-maint/debug/lib
 
 module load fenics/tferma-master/petsc-maint/debug
 

--- a/terraferma/master/fenics-tferma-master/petsc-maint/reldebug
+++ b/terraferma/master/fenics-tferma-master/petsc-maint/reldebug
@@ -6,14 +6,14 @@ proc ModulesHelp { } {
 }
 module-whatis "Sets environment for TerraFERMA and Buckettools."
 
-setenv       TF_CMAKE_PATH         /usr/local/tferma/master/fenics-tferma-master/petsc-maint/reldebug/share/terraferma/cpp
-prepend-path CMAKE_MODULE_PATH     /usr/local/tferma/master/fenics-tferma-master/petsc-maint/reldebug/share/buckettools/cmake/modules
-prepend-path PYTHONPATH            /usr/local/tferma/master/fenics-tferma-master/petsc-maint/reldebug/lib/python2.7/dist-packages:/usr/local/tferma/master/fenics-tferma-master/petsc-maint/reldebug/lib/python2.7/site-packages
-prepend-path DIAMOND_CONFIG_PATH   /usr/local/tferma/master/fenics-tferma-master/petsc-maint/reldebug/share/buckettools/diamond
-prepend-path PATH                  /usr/local/tferma/master/fenics-tferma-master/petsc-maint/reldebug/bin
+setenv       TF_CMAKE_PATH         /usr/local/terraferma/master/fenics-tferma-master/petsc-maint/reldebug/share/terraferma/cpp
+prepend-path CMAKE_MODULE_PATH     /usr/local/terraferma/master/fenics-tferma-master/petsc-maint/reldebug/share/buckettools/cmake/modules
+prepend-path PYTHONPATH            /usr/local/terraferma/master/fenics-tferma-master/petsc-maint/reldebug/lib/python2.7/dist-packages:/usr/local/terraferma/master/fenics-tferma-master/petsc-maint/reldebug/lib/python2.7/site-packages
+prepend-path DIAMOND_CONFIG_PATH   /usr/local/terraferma/master/fenics-tferma-master/petsc-maint/reldebug/share/buckettools/diamond
+prepend-path PATH                  /usr/local/terraferma/master/fenics-tferma-master/petsc-maint/reldebug/bin
 
 # Special Environment variables for resolving Dynamic Libraries on MacOSX
-prepend-path DYLD_LIBRARY_PATH     /usr/local/tferma/master/fenics-tferma-master/petsc-maint/reldebug/lib
+prepend-path DYLD_LIBRARY_PATH     /usr/local/terraferma/master/fenics-tferma-master/petsc-maint/reldebug/lib
 
 module load fenics/tferma-master/petsc-maint/reldebug
 


### PR DESCRIPTION
environment modules had all paths to /usr/local/tferma but (at least on blakey) the new paths from github are /usr/local/terraferma.  This branch attempts to fix that but needs to be tested.
